### PR TITLE
Document `-i`, `-p`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Help Options:
 Application Options:
   -v, --version                        Display version number
   -s, --socket=<Socket URI>            Socket path for i3
-  -c, --file=<Path to config file>     Config file
-  -t, --style=<Path to style file>     CSS file
+  -c <Path to config file>             Config file
+  -i <Read from standard input>        Read from standard input
+  -t <Path to style file>              CSS file
+  -p <comment line prefix>             Prefix of comment line
 
 ```
 
-Remontoire communicates with i3 via domain sockets to retrieve the active i3 config file.  To determine the socket path on a system running i3:
+With `-s`, Remontoire communicates with i3 via domain sockets to retrieve the active i3 config file.  To determine the socket path on a system running i3:
 ```bash
 $ i3 --get-socketpath
 ```
@@ -68,6 +70,9 @@ Remontoire can also be passed a file path and will read from that instead of the
 ```bash
 $ remontoire -c /etc/something/interesting.conf
 ```
+
+As a third option to provide your config files, Remontoire can read from STDIN. Use this option
+if you want to pass in the contents of multiple config files.
 
 Once executed Remontoire will display a sticky floating window on the right-center of the primary monitor. Upon first launch, all categories are collapsed.  User selections to open categories are persisted across instantiations of the program.
 
@@ -191,6 +196,12 @@ You can specify a custom CSS file to change the look of the dialog.  The built-i
   margin: 2px;
 }
 ```
+
+## Using Remontoire to view keybindings for arbitrary config files
+
+Since Remontoire parses comments and not actual keybindings, it can be used as a keybinding viewer for any app that stores keybindings in plain text and supports comments, like Sway or Vim. Use the `-c` or  `-i` options documented above to supply the config files. If config doesn't use `#` as a comment prefix, you use the `-p` option to supply comment prefix to go immediately before '##'. Here's an example of parsing a comment using Vim's quote character as a prefix:
+
+    echo '"## Category // Description // <Super> J ##' | remontoire -i -p '"'
 
 ## Install Package
 

--- a/src/main.vala
+++ b/src/main.vala
@@ -51,7 +51,7 @@ int main (string[] args) {
         config_reader = read_stdin_config;
         config_descriptor = "";
     } else {
-        printerr ("Must specify either socket URI to i3 socket or file path to config file.\n");
+        printerr ("Must specify -s <i3 Socket URI>, -c <Config file path> or -i <STDIN>.\n");
         printerr ("Run '%s --help' to see a full list of available command line options.\n", args[0]);
         return 1;
     }


### PR DESCRIPTION
This adds documentation to the README for `-i` and `-p` added by
90dff5ae9906708e591358976a554e1ec01743dd

A diagnostic message is also corrected to note `-i` is a valid option
to provide the config files.

This further addresses the user experience for #9 and #10.
