### PR TITLE
Update to correct version for reporting

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -15,7 +15,7 @@ int main (string[] args) {
     }
 
     if (argMap.has_key ("-v") || argMap.has_key ("--version")) {
-        print ("remontoire 1.3.0 (C) 2020 Ken Gilmer\n");
+        print ("remontoire 1.4.0 (C) 2020 Ken Gilmer\n");
         return 0;
     }
 


### PR DESCRIPTION
Running `remontoire --version` still reports `remontoire 1.4.0 (C) 2020 Ken Gilmer` because it never got changed here, even though 1.4.0 is out. Even if you download 1.4.0 yourself, it still reports as being 1.3.0 when you run `--version`. This fixes it.