### PR TITLE
Fedora installation and fixing table with summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ $ sudo zypper ref
 $ sudo zypper in remontoire
 ```
 
+### Fedora
+
+Remontoire is available in [X3MBoy's Copr](https://copr.fedorainfracloud.org/coprs/x3mboy/remontoire/). Install is available for Fedora 40, 41, 42 and rawhide:
+
+```
+sudo dnf copr enable x3mboy/remontoire
+sudo dnf install remontoire
+```
+
 ## Build from Source
 
 Meson, Vala and Gtk+ libraries are required to build.  After downloading sources, from within the project root, execute the following:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 ## Summary
 
-<table><tr><td>
-<p>Remontoire is a small (~71Kb) GTK app for presenting keybinding hints in a compact form suitable for tiling window environments.  It is intended for use with the i3 window manager but it's also able to display keybindings from any suitably formatted config file.</p>
-
-<p>The program functions by scanning and parsing comments in a specific format (described directly below), then displaying them in a one-layer categorized list view.  The program stores the state of which sections are expanded, allowing for use on screens with limited resolution.</p>
-</td><td><img src="https://regolith-linux.org/regolith-site-r14-beta/docs/reference/releases/regolith-remontoire-screenshot-131.png"/>
-</td></tr></table>
+| Summary | Screenshot |
+| ------- | ---------- | 
+| Remontoire is a small (~71Kb) GTK app for presenting keybinding hints in a compact form suitable for tiling window environments.  It is intended for use with the i3 window manager but it's also able to display keybindings from any suitably formatted config file. The program functions by scanning and parsing comments in a specific format (described directly below), then displaying them in a one-layer categorized list view.  The program stores the state of which sections are expanded, allowing for use on screens with limited resolution. | ![screenshot](https://regolith-linux.org/images/releases/regolith-remontoire-screenshot-131.png) |
 
 ## Model
 


### PR DESCRIPTION
I did some work on the README.md file, so it includes the way to install remontoire from my copr, and also I fixed the image and the table on the beginning so it looks better.