### PR TITLE
Updating Application Description on appdata.xml.in

### DIFF
--- a/data/org.regolith-linux.remontoire.appdata.xml.in
+++ b/data/org.regolith-linux.remontoire.appdata.xml.in
@@ -3,5 +3,8 @@
 	<id>org.gnome.Remontoire.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
-	<description>Desktop xml's description</description>
+	<description>
+		<p>Remontoire is a small (~71Kb) GTK app for presenting keybinding hints in a compact form suitable for tiling window environments. It is intended for use with the i3 window manager but it's also able to display keybindings from any suitably formatted config file.</p>
+		<p>The program functions by scanning and parsing comments in a specific format (described directly below), then displaying them in a one-layer categorized list view. The program stores the state of which sections are expanded, allowing for use on screens with limited resolution.</p>
+	</description>
 </component>

--- a/data/org.regolith-linux.remontoire.appdata.xml.in
+++ b/data/org.regolith-linux.remontoire.appdata.xml.in
@@ -5,6 +5,6 @@
 	<project_license>GPL-3.0-or-later</project_license>
 	<description>
 		<p>Remontoire is a small (~71Kb) GTK app for presenting keybinding hints in a compact form suitable for tiling window environments. It is intended for use with the i3 window manager but it's also able to display keybindings from any suitably formatted config file.</p>
-		<p>The program functions by scanning and parsing comments in a specific format (described directly below), then displaying them in a one-layer categorized list view. The program stores the state of which sections are expanded, allowing for use on screens with limited resolution.</p>
+		<p>The program functions by scanning and parsing comments in a specific format, then displaying them in a one-layer categorized list view. The program stores the state of which sections are expanded, allowing for use on screens with limited resolution.</p>
 	</description>
 </component>


### PR DESCRIPTION
Updating `org.regolith-linux.remontoire.appdata.xml.in` to a wider and more descriptive description.